### PR TITLE
Migrate Account Number Type to String

### DIFF
--- a/src/Account/Account.java
+++ b/src/Account/Account.java
@@ -6,7 +6,7 @@ package Account;
  * @version 1.00 2021/04/22
  */
 public class Account {
-    private long account_number;
+    private String account_number;
     private double balance;
 
     /**
@@ -15,7 +15,7 @@ public class Account {
      * @param account_number account number of the client
      * @param balance initial balance of the client
      */
-    public Account(long account_number, double balance) {
+    public Account(String account_number, double balance) {
         setAccountNumber(account_number);
         setBalance(balance);
     }
@@ -24,7 +24,7 @@ public class Account {
      * Returns the account number
      * @return account_number
      */
-    public long getAccountNumber() {
+    public String getAccountNumber() {
         return account_number;
     }
 
@@ -40,7 +40,7 @@ public class Account {
      * Sets the client's account number
      * @param account_number account number of the client
      */
-    public void setAccountNumber(long account_number) {
+    public void setAccountNumber(String account_number) {
         this.account_number = account_number;
     }
 

--- a/src/Account/SpecialAccount.java
+++ b/src/Account/SpecialAccount.java
@@ -14,7 +14,7 @@ public class SpecialAccount extends Account{
      * @param account_number account number of the client
      * @param balance initial balance of the client
      */
-    public SpecialAccount(long account_number, double balance) {
+    public SpecialAccount(String account_number, double balance) {
         super(account_number, balance); // Calls Account constructor
     }
 

--- a/src/Account/TestAccount.java
+++ b/src/Account/TestAccount.java
@@ -3,8 +3,8 @@ package Account;
 
 public class TestAccount {
     public static void main(String[] args) {
-        Account account = new Account(52464584, 500);
-        SpecialAccount specialAccount = new SpecialAccount(526565, 2565);
+        Account account = new Account("52464548445698", 500);
+        SpecialAccount specialAccount = new SpecialAccount("52665423125565", 2565);
 
         // Display accounts information
         System.out.println(account);

--- a/src/Client/TestClient.java
+++ b/src/Client/TestClient.java
@@ -4,8 +4,8 @@ import Account.Account;
 
 public class TestClient {
     public static void main(String[] args) {
-        Account account = new Account(25478688, 15000);
-        Account commercialAccount = new Account(25616564, 250365);
+        Account account = new Account("25479858968688", 15000);
+        Account commercialAccount = new Account("25741295616564", 250365);
         Client client = new Client("Guy Cherubin", 12254125458654L,
                 "Dokki Gizah", "01228331194", account);
 

--- a/src/Main.java
+++ b/src/Main.java
@@ -43,7 +43,7 @@ public class Main {
             System.out.println("\nPlease Enter Account information below");
             int accountType = getAccountType();
             System.out.print("Account Number: ");
-            long accountNumber = input.nextLong();
+            String accountNumber = input.next();
             System.out.print("Account balance: ");
             double balance = input.nextDouble();
 


### PR DESCRIPTION
Account Number is migrated to String instead of long so that each account number can be checked if its length is 14 more easily
